### PR TITLE
Update sha256

### DIFF
--- a/Formula/karrots.rb
+++ b/Formula/karrots.rb
@@ -2,7 +2,7 @@ class Karrots < Formula
   desc "creates fully gitops-automated kubernetes clusters"
   homepage "https://zero-diff.github.io/karrots"
   url "https://zero-diff.github.io/karrots/releases/binaries/brew/karrots.tar.gz"
-  sha256 "04f9a5da002c47023f4a4a429923f9ace083de2a0f091206f5a5f53e8b6284a0"
+  sha256 "fee200d9cc15b934598a4df2724f1925768bb251156ecb95ab1ad00d9ef547b6"
   version "0.1.0"
   
   depends_on "git"


### PR DESCRIPTION
Performing a brew install was failing due to a SHA mismatch ... this updates the SHA in the formula to match that of the file

```
tahoe:~ eric$ brew install karrots hub
Updating Homebrew...
==> Installing karrots from zero-diff/karrots
==> Downloading https://homebrew.bintray.com/bottles/gettext-0.21.mojave.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/99707d4dcc731faf980333365a694e9500f2f012f84c0bcb6d8cb5d620c2ce08?response-content-disposition=attachment%3Bfilename%3D%22gettext-0.21.mojave.bott
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/pcre2-10.35.mojave.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/d7be9b0193654484e40bc30dd330711cc1e72fa9bf29f854dd50458f6a827d1b?response-content-disposition=attachment%3Bfilename%3D%22pcre2-10.35.mojave.bottl
######################################################################## 100.0%
==> Downloading https://homebrew.bintray.com/bottles/git-2.28.0.mojave.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/10f23bc63568fdeb598df2dd30fbb0ead31f2eef3c0990a8ac53f3e2005de82f?response-content-disposition=attachment%3Bfilename%3D%22git-2.28.0.mojave.bottle
######################################################################## 100.0%
==> Downloading https://zero-diff.github.io/karrots/releases/binaries/brew/karrots.tar.gz
==> Downloading from https://karrots.zerodiff.org/releases/binaries/brew/karrots.tar.gz
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: 04f9a5da002c47023f4a4a429923f9ace083de2a0f091206f5a5f53e8b6284a0
  Actual: fee200d9cc15b934598a4df2724f1925768bb251156ecb95ab1ad00d9ef547b6
 Archive: /Users/eric/Library/Caches/Homebrew/downloads/04db3fc00e27da5a11dbdaf1a6d4dee83baafbe0866717bd90980c478804e55d--karrots.tar.gz
To retry an incomplete download, remove the file above.
``` 